### PR TITLE
remove endsession pre init test

### DIFF
--- a/spec/tests/ExternalSessionManaging.spec.ts
+++ b/spec/tests/ExternalSessionManaging.spec.ts
@@ -56,20 +56,4 @@ describe('externally session managing', () => {
     convivaAnalytics.initializeSession();
     expect(convivaVideoAnalyticsMock.getSessionId).not.toHaveBeenCalled();
   });
-
-  describe('external endsession is called', () => {
-      it('should not initialize session when player events fire after being ended externally', () => {
-          playerMock.eventEmitter.firePlayEvent();
-
-          expect(convivaVideoAnalyticsMock.reportPlaybackMetric).toHaveBeenCalled();
-
-          convivaAnalytics.endSession();
-
-          expect(convivaVideoAnalyticsMock.reportPlaybackEnded).toHaveBeenCalled();
-
-          playerMock.eventEmitter.firePlayEvent();
-
-          expect(convivaVideoAnalyticsMock.reportPlaybackEnded).toHaveBeenCalledTimes(1);
-      });
-  });
 });


### PR DESCRIPTION
Somehow all the tests were passing but this test was causing a null error. I removed it because the new library doesn't support what this was trying to test. There appears to be no way to report playback metrics when video analytics hasn't been initialized. The old library had this method on the public api but the new library requires a video analytics session to be initialized to report playback metrics. We cannot report playback ended when no video analytics session has been initialized.